### PR TITLE
Make Yenta buildable on modern JDK + Maven combination:

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+/demo/target/
+/app/target/
+/api/target/
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,2 @@
-/demo/target/
-/app/target/
-/api/target/
+target
 *.orig
-/lib/target/

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -17,7 +17,7 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
+                <groupId>org.apache.netbeans.utilities</groupId>
                 <artifactId>nbm-maven-plugin</artifactId>
                 <extensions>true</extensions>
                 <configuration>
@@ -30,9 +30,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <configuration>
-                    <useDefaultManifestFile>true</useDefaultManifestFile>
-                </configuration>
             </plugin>
         </plugins>
     </build>
@@ -40,7 +37,7 @@
         <dependency>
             <groupId>org.netbeans.api</groupId>
             <artifactId>org-openide-modules</artifactId>
-            <version>RELEASE72</version>
+            <version>${netbeans.version}</version>
         </dependency>
     </dependencies>
 </project>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.netbeans.contrib.yenta</groupId>
         <artifactId>parent</artifactId>
-        <version>1.2</version>
+        <version>1.2-SNAPSHOT</version>
     </parent>
     <artifactId>api</artifactId>
     <packaging>nbm</packaging>

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -37,13 +37,13 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
+                <groupId>org.apache.netbeans.utilities</groupId>
                 <artifactId>nbm-maven-plugin</artifactId>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.12.2</version>
+                <version>2.22.2</version>
                 <configuration>
                     <systemPropertyVariables>
                         <all.clusters>${all.clusters}</all.clusters>
@@ -54,7 +54,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-deploy-plugin</artifactId>
-                <version>2.7</version>
+                <version>2.8.2</version>
                 <configuration>
                     <skip>true</skip>
                 </configuration>

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.netbeans.contrib.yenta</groupId>
         <artifactId>parent</artifactId>
-        <version>1.2</version>
+        <version>1.2-SNAPSHOT</version>
     </parent>
     <artifactId>app</artifactId>
     <packaging>nbm-application</packaging>

--- a/demo/pom.xml
+++ b/demo/pom.xml
@@ -15,7 +15,7 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
+                <groupId>org.apache.netbeans.utilities</groupId>
                 <artifactId>nbm-maven-plugin</artifactId>
                 <configuration>
                     <verifyRuntime>warn</verifyRuntime>
@@ -24,14 +24,11 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <configuration>
-                    <useDefaultManifestFile>true</useDefaultManifestFile>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-deploy-plugin</artifactId>
-                <version>2.7</version>
+                <version>2.8.2</version>
                 <configuration>
                     <skip>true</skip>
                 </configuration>

--- a/lib/pom.xml
+++ b/lib/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.netbeans.contrib.yenta</groupId>
         <artifactId>parent</artifactId>
-        <version>1.2</version>
+        <version>1.2-SNAPSHOT</version>
     </parent>
     <artifactId>lib</artifactId>
     <name>Yenta API as library jar</name>

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
         <url>https://github.com/jglick/yenta.git</url>
         <connection>scm:git:https://github.com/jglick/yenta.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/jglick/yenta</developerConnection>
-        <tag>yenta-1.1</tag>
+        <tag>HEAD</tag>
     </scm>
     <build>
         <pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     </parent>
     <groupId>org.netbeans.contrib.yenta</groupId>
     <artifactId>parent</artifactId>
-    <version>1.2</version>
+    <version>1.2-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Yenta</name>
     <description>NetBeans module system hacks.</description>

--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
         <module>lib</module>
     </modules>
     <properties>
-        <netbeans.version>RELEASE111</netbeans.version>
+        <netbeans.version>RELEASE124</netbeans.version>
         <brandingToken>yenta</brandingToken>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -30,8 +30,8 @@
         <url>https://bitbucket.org/jglick/yenta</url>
         <connection>scm:hg:https://bitbucket.org/jglick/yenta</connection>
         <developerConnection>scm:hg:ssh://hg@bitbucket.org/jglick/yenta</developerConnection>
-      <tag>yenta-1.1</tag>
-  </scm>
+        <tag>yenta-1.1</tag>
+    </scm>
     <repositories>
         <repository>
             <id>netbeans</id>
@@ -49,9 +49,9 @@
         <pluginManagement>
             <plugins>
                 <plugin>
-                    <groupId>org.codehaus.mojo</groupId>
+                    <groupId>org.apache.netbeans.utilities</groupId>
                     <artifactId>nbm-maven-plugin</artifactId>
-                    <version>3.8.1</version>
+                    <version>4.5</version>
                     <extensions>true</extensions>
                     <configuration>
                         <brandingToken>${brandingToken}</brandingToken>
@@ -61,21 +61,26 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>2.5.1</version>
+                    <version>3.8.1</version>
                     <configuration>
-                        <source>1.6</source>
-                        <target>1.6</target>
+                        <source>8</source>
+                        <target>8</target>
                     </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jar-plugin</artifactId>
-                    <version>2.4</version>
+                    <version>3.2.0</version>
+                    <configuration>
+                        <archive>
+                            <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                        </archive>
+                    </configuration>                    
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-release-plugin</artifactId>
-                    <version>2.3.2</version>
+                    <version>2.5.3</version>
                     <configuration>
                         <tagNameFormat>yenta-@{project.version}</tagNameFormat>
                         <arguments>-Psonatype-oss-release,stapler-sign</arguments>
@@ -90,7 +95,7 @@
         <module>app</module>
     </modules>
     <properties>
-        <netbeans.version>RELEASE72</netbeans.version>
+        <netbeans.version>RELEASE111</netbeans.version>
         <brandingToken>yenta</brandingToken>
     </properties>
 </project>


### PR DESCRIPTION
Make Yenta buildable on modern JDK + Maven combination:
    
 * Use new coordinates for NBM Maven Plugin
 * Newer versions of serveral plugins which were
   causing classloading problems w/ conflicting aether versions in Maven 3.6.3
 * Use source version recognized by newer JDKs' javac
 * Work around bug in nbm-maven-plugin when testing app project the
   first time (subsequent runs succeed)
 * Merge with Milos' patches
 * Minor pom cleanup

No semantic code changes.